### PR TITLE
Context specific identifiers

### DIFF
--- a/ASN1Decoder.xcodeproj/project.pbxproj
+++ b/ASN1Decoder.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		41D14FE31F58C15A0058DE7A /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D14FE21F58C1590058DE7A /* PKCS7.swift */; };
 		D4BFF228216412880050FD38 /* ASN1PublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BFF227216412880050FD38 /* ASN1PublicKey.swift */; };
 		D4BFF22A21641B450050FD38 /* X509CertificateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BFF22921641B450050FD38 /* X509CertificateTests.swift */; };
+		D4E3AF81217A595300E79F8D /* ASN1ContextSpecificIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E3AF80217A595300E79F8D /* ASN1ContextSpecificIdentifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,7 @@
 		41D14FE21F58C1590058DE7A /* PKCS7.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PKCS7.swift; sourceTree = "<group>"; };
 		D4BFF227216412880050FD38 /* ASN1PublicKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1PublicKey.swift; sourceTree = "<group>"; };
 		D4BFF22921641B450050FD38 /* X509CertificateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = X509CertificateTests.swift; sourceTree = "<group>"; };
+		D4E3AF80217A595300E79F8D /* ASN1ContextSpecificIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASN1ContextSpecificIdentifier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +89,7 @@
 		412A9E3A1F55C6500099110C /* ASN1Decoder */ = {
 			isa = PBXGroup;
 			children = (
+				D4E3AF80217A595300E79F8D /* ASN1ContextSpecificIdentifier.swift */,
 				412A9E3B1F55C6500099110C /* ASN1Decoder.h */,
 				412A9E521F55C6830099110C /* ASN1Decoder.swift */,
 				412A9E531F55C6830099110C /* ASN1Identifier.swift */,
@@ -229,6 +232,7 @@
 				412A9E591F55C6830099110C /* X509Certificate.swift in Sources */,
 				412A9E561F55C6830099110C /* ASN1Decoder.swift in Sources */,
 				412A9E571F55C6830099110C /* ASN1Identifier.swift in Sources */,
+				D4E3AF81217A595300E79F8D /* ASN1ContextSpecificIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ASN1Decoder/ASN1ContextSpecificIdentifier.swift
+++ b/ASN1Decoder/ASN1ContextSpecificIdentifier.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public protocol ASN1ContextSpecificIdentifier: RawRepresentable where RawValue == UInt8 {}
+
+public enum SubjectAlternativeNamesIdentifier: UInt8, ASN1ContextSpecificIdentifier {
+    /* From https://tools.ietf.org/html/rfc5280#section-4.2.1.6
+     -- subject alternative name extension OID and syntax
+
+     id-ce-subjectAltName OBJECT IDENTIFIER ::=  { id-ce 17 }
+
+     SubjectAltName ::= GeneralNames
+
+     GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+
+     GeneralName ::= CHOICE {
+     otherName                 [0]  AnotherName,
+     rfc822Name                [1]  IA5String,
+     dNSName                   [2]  IA5String,
+     x400Address               [3]  ORAddress,
+     directoryName             [4]  Name,
+     ediPartyName              [5]  EDIPartyName,
+     uniformResourceIdentifier [6]  IA5String,
+     iPAddress                 [7]  OCTET STRING,
+     registeredID              [8]  OBJECT IDENTIFIER }
+     */
+    case otherName = 0
+    case rfc822Name
+    case dNSName
+    case x400Address
+    case directoryName
+    case ediPartyName
+    case uniformResourceIdentifier
+    case iPAddress
+    case registeredID
+}

--- a/ASN1Decoder/ASN1Identifier.swift
+++ b/ASN1Decoder/ASN1Identifier.swift
@@ -90,6 +90,10 @@ public class ASN1Identifier: CustomStringConvertible {
         return TagNumber(rawValue: rawValue & 0x1F) ?? .endOfContent
     }
 
+    func contextualIdentifier<T: ASN1ContextSpecificIdentifier>() -> T? {
+        return T(rawValue: self.tagNumber().rawValue)
+    }
+
     public var description: String {
         if typeClass() == .universal {
             return String(describing: tagNumber())

--- a/ASN1Decoder/X509Certificate.swift
+++ b/ASN1Decoder/X509Certificate.swift
@@ -218,8 +218,7 @@ public class X509Certificate: CustomStringConvertible {
 
     /// Gets a collection of subject alternative names from the SubjectAltName extension, (OID = 2.5.29.17).
     public var subjectAlternativeNames: [(identifier: SubjectAlternativeNamesIdentifier, value: String)] {
-        return extensionObject(oid: OID_SubjectAltName)?.block.sub?.flatMap {
-
+        return extensionObject(oid: OID_SubjectAltName)?.block.sub?.compactMap {
             guard let object = $0.sub?.last?.sub?.last,
                 let identifier: SubjectAlternativeNamesIdentifier = object.identifier?.contextualIdentifier(),
                 let value = object.value as? String else { return nil }

--- a/ASN1Decoder/X509Certificate.swift
+++ b/ASN1Decoder/X509Certificate.swift
@@ -218,10 +218,9 @@ public class X509Certificate: CustomStringConvertible {
 
     /// Gets a collection of subject alternative names from the SubjectAltName extension, (OID = 2.5.29.17).
     public var subjectAlternativeNames: [(identifier: SubjectAlternativeNamesIdentifier, value: String)] {
-        return extensionObject(oid: OID_SubjectAltName)?.block.sub?.compactMap {
-            guard let object = $0.sub?.last?.sub?.last,
-                let identifier: SubjectAlternativeNamesIdentifier = object.identifier?.contextualIdentifier(),
-                let value = object.value as? String else { return nil }
+        return extensionObject(oid: OID_SubjectAltName)?.block.sub?.last?.sub?.last?.sub?.compactMap {
+            guard let identifier: SubjectAlternativeNamesIdentifier = $0.identifier?.contextualIdentifier(),
+                let value = $0.value as? String else { return nil }
             return (identifier, value)
         } ?? []
     }

--- a/ASN1Decoder/X509Certificate.swift
+++ b/ASN1Decoder/X509Certificate.swift
@@ -217,8 +217,14 @@ public class X509Certificate: CustomStringConvertible {
     }
 
     /// Gets a collection of subject alternative names from the SubjectAltName extension, (OID = 2.5.29.17).
-    public var subjectAlternativeNames: [String] {
-        return extensionObject(oid: OID_SubjectAltName)?.valueAsStrings ?? []
+    public var subjectAlternativeNames: [(identifier: SubjectAlternativeNamesIdentifier, value: String)] {
+        return extensionObject(oid: OID_SubjectAltName)?.block.sub?.flatMap {
+
+            guard let object = $0.sub?.last?.sub?.last,
+                let identifier: SubjectAlternativeNamesIdentifier = object.identifier?.contextualIdentifier(),
+                let value = object.value as? String else { return nil }
+            return (identifier, value)
+        } ?? []
     }
 
     /// Gets a collection of issuer alternative names from the IssuerAltName extension, (OID = 2.5.29.18).

--- a/ASN1DecoderTests/X509CertificateTests.swift
+++ b/ASN1DecoderTests/X509CertificateTests.swift
@@ -41,13 +41,15 @@ class X509CertificateTests: XCTestCase {
     }
 
     func testParsingAnternativeNames() throws {
-        XCTAssertEqual(try x509().subjectAlternativeNames, ["www.digicert.com",
-                                                            "digicert.com",
-                                                            "content.digicert.com",
-                                                            "www.origin.digicert.com",
-                                                            "login.digicert.com",
-                                                            "api.digicert.com",
-                                                            "ws.digicert.com"])
+        let objects = try x509().subjectAlternativeNames
+        objects.forEach { XCTAssertEqual($0.identifier, .dNSName) }
+        XCTAssertEqual(objects.map { $0.value }, ["www.digicert.com",
+                                                  "digicert.com",
+                                                  "content.digicert.com",
+                                                  "www.origin.digicert.com",
+                                                  "login.digicert.com",
+                                                  "api.digicert.com",
+                                                  "ws.digicert.com"])
     }
 
     func testParsingNotAfter() throws {


### PR DESCRIPTION
**Add support for context-specific ASN1 identifiers**

- Adds Subject Alternative Names identifiers (according to the [RFC](https://tools.ietf.org/html/rfc5280#section-4.2.1.6))
- Adds a method to create a context-specific identifier from the generic `ASN1Identifier`
- Change `subjectAlternativeNames` method on `X509Certificate` to return a tuple of `(SubjectAlternativeNameIdentifier, String)`